### PR TITLE
Support for Firmata4j library

### DIFF
--- a/examples/BluefruitLE_nrf51822/BluefruitLE_nrf51822.ino
+++ b/examples/BluefruitLE_nrf51822/BluefruitLE_nrf51822.ino
@@ -739,7 +739,7 @@ void setup()
 
 void firmataInit() {
   FIRMATADEBUG.println(F("Init firmata"));
-  //BLE_Firmata.setFirmwareVersion(FIRMATA_MAJOR_VERSION, FIRMATA_MINOR_VERSION);
+  BLE_Firmata.setFirmwareVersion(FIRMATA_MAJOR_VERSION, FIRMATA_MINOR_VERSION);
   //FIRMATADEBUG.println(F("firmata analog"));
   BLE_Firmata.attach(ANALOG_MESSAGE, analogWriteCallback);
   //FIRMATADEBUG.println(F("firmata digital"));


### PR DESCRIPTION
In order to initialize Java [Firmata4j](https://github.com/kurbatov/firmata4j) library ,
 which can be used on android projects, the firmare version of firmata device is required
Solution successfuly tested on: Adafruit Feather BLE 32u4