### PR TITLE
Fixed Markdown formatting and updated macOS name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#Firmata
+# Firmata
 
 Firmata is a protocol for communicating with microcontrollers from software on a host computer. The [protocol](http://firmata.org/wiki/Protocol) can be implemented in firmware on any microcontroller architecture as well as software on any host computer software package. The arduino repository described here is a Firmata library for Arduino and Arduino-compatible devices. See the [firmata wiki](http://firmata.org/wiki/Main_Page) for additional informataion. If you would like to contribute to Firmata, please see the [Contributing](#contributing) section below.
 
-##Usage
+## Usage
 
 There are two main models of usage of Firmata. In one model, the author of the Arduino sketch uses the various methods provided by the Firmata library to selectively send and receive data between the Arduino device and the software running on the host computer. For example, a user can send analog data to the host using ``` Firmata.sendAnalog(analogPin, analogRead(analogPin)) ``` or send data packed in a string using ``` Firmata.sendString(stringToSend) ```. See File -> Examples -> Firmata -> AnalogFirmata & EchoString respectively for examples.
 
 The second and more common model is to load a general purpose sketch called StandardFirmata on the Arduino board and then use the host computer exclusively to interact with the Arduino board. StandardFirmata is located in the Arduino IDE in File -> Examples -> Firmata.
 
-##Firmata Client Libraries
+## Firmata Client Libraries
 Most of the time you will be interacting with arduino with a client library on the host computers. Several Firmata client libraries have been implemented in a variety of popular programming languages:
 
 * procesing
@@ -44,10 +44,10 @@ Most of the time you will be interacting with arduino with a client library on t
 
 Note: The above libraries may support various versions of the Firmata protocol and therefore may not support all features of the latest Firmata spec nor all arduino and arduino-compatible boards. Refer to the respective projects for details.
 
-##Updating Firmata in the Arduino IDE (< Arduino 1.5)
+## Updating Firmata in the Arduino IDE (< Arduino 1.5)
 The version of firmata in the Arduino IDE contains an outdated version of Firmata. To update Firmata, clone the repo into the location of firmata in the arduino IDE or download the latest [tagged version](https://github.com/firmata/arduino/tags) (stable), rename the folder to "Firmata" and replace the existing Firmata folder in your Ardino application.
 
-**Mac OSX**:
+**macOS**:
 
 ```bash
 $ rm -r /Applications/Arduino.app/Contents/Resources/Java/libraries/Firmata
@@ -81,7 +81,7 @@ As of Arduino 1.5.2 and there are separate library directories for the sam and
 avr architectures. To update Firmata in Arduino 1.5.2 or higher, follow the 
 instructions above for pre Arduino 1.5 versions but update the path as follows:
 
-**Mac OSX**:
+**macOS**:
 ```
 /Applications/Arduino.app/Contents/Resources/Java/hardware/arduino/avr/libraries/Firmata
 /Applications/Arduino.app/Contents/Resources/Java/hardware/arduino/sam/libraries/Firmata
@@ -100,7 +100,7 @@ instructions above for pre Arduino 1.5 versions but update the path as follows:
 ```
 
 <a name="contributing" />
-##Contributing
+## Contributing
 
 If you discover a bug or would like to propose a new feature, please open a new [issue](https://github.com/firmata/arduino/issues?sort=created&state=open). Due to the limited memory of standard Arduino boards we cannot add every requested feature to StandardFirmata. Requests to add new features to StandardFirmata will be evaluated by the Firmata developers. However it is still possible to add new features to other Firmata implementations (Firmata is a protocol whereas StandardFirmata is just one of many possible implementations).
 


### PR DESCRIPTION
**Simple Markdown formatting fixes in README** Headings require a space between the markup (e.g. `#`) and the title to render as headings; also updated the the Mac-related sections to use the current "macOS" name.
